### PR TITLE
Fix the latest master

### DIFF
--- a/lyricify/controller.py
+++ b/lyricify/controller.py
@@ -7,7 +7,6 @@ from gi.repository import GLib
 
 from lyricify import lyrics
 from lyricify.gui import LyricifyUI
-from lyricify import cli
 
 
 class SpotifyDBus():
@@ -32,7 +31,7 @@ class SpotifyDBus():
                 "/org/mpris/MediaPlayer2")
             self.spotify_bus.connect_to_signal("PropertiesChanged",
                                                self.on_change)
-        except:
+        except Exception:
             print("Could not connect to Spotify, exiting...")
             sys.exit()
 
@@ -93,4 +92,4 @@ def main():
 
 
 if __name__ == "__main__":
-        main()
+    main()


### PR DESCRIPTION
'controller.py' has a reference to a `lyricify.cli` module which no
longer exists. Luckily, this module is just imported and not used, so
removing it results in the application working again.

I did some minor fixes (indentation and fixing a bare `except`
statement) in the file as well.